### PR TITLE
Adding cron recipe to setup regular backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ This cookbook recommends on the following cookbooks:
 
 * Debian
 * Ubuntu
+* CentOS
+* RHEL
 
 Attributes
 ==========
 
 ### repository.rb:
 
-* `node['hollandbackup']['repository']['distro']` - The Linux distro, defaults to "xUbuntu_12.04"
+* `node['hollandbackup']['repository']['distro']` - The Linux distro to use, check the [openSUSE repositories](http://download.opensuse.org/repositories/home:/holland-backup/) for the proper name for your distro
 
 ### mysqldump.rb:
 * See http://docs.hollandbackup.org/provider_configs/mysqldump.html

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Requirements
 
 ## Cookbooks:
 
+This cookbook depends on the following cookbooks:
+
+* cron
+
 This cookbook recommends on the following cookbooks:
 
 * mysql
@@ -26,11 +30,12 @@ This cookbook recommends on the following cookbooks:
 Attributes
 ==========
 
-## repository.rb:
+### repository.rb:
 
 * `node['hollandbackup']['repository']['distro']` - The Linux distro, defaults to "xUbuntu_12.04"
 
-## mysqldump.rb: (see http://docs.hollandbackup.org/provider_configs/mysqldump.html)
+### mysqldump.rb:
+* See http://docs.hollandbackup.org/provider_configs/mysqldump.html
 
 ### general
 * `node['hollandbackup']['mysqldump']['mysql_binpath']` - see Holland Backup mysqldump-docs, defaults to nil
@@ -52,7 +57,7 @@ Attributes
 * `node['hollandbackup']['mysqldump']['filtering']['tables']` - see Holland Backup mysqldump-docs, defaults to nil
 * `node['hollandbackup']['mysqldump']['filtering']['exclude_tables']` - see Holland Backup mysqldump-docs, defaults to nil
 
-### [compression]
+#### [compression]
 * `node['hollandbackup']['mysqldump']['compresssion']['method']` - see Holland Backup mysqldump-docs, defaults to nil
 * `node['hollandbackup']['mysqldump']['compresssion']['inline']` - see Holland Backup mysqldump-docs, defaults to nil
 * `node['hollandbackup']['mysqldump']['compresssion']['level']` - see Holland Backup mysqldump-docs, defaults to nil
@@ -66,21 +71,33 @@ Attributes
 * `node['hollandbackup']['mysqldump']['mysql_connection']['host']` - see Holland Backup mysqldump-docs, defaults to nil
 * `node['hollandbackup']['mysqldump']['mysql_connection']['port']` - see Holland Backup mysqldump-docs, defaults to nil
 
-## main.rb: (see http://docs.hollandbackup.org/config.html#holland-conf-main-config)
-### [holland]
+### main.rb:
+* See http://docs.hollandbackup.org/config.html#holland-conf-main-config
+
+#### [holland]
 * `node['hollandbackup']['main']['plugin_dirs']` - see Holland Backup main config-docs, defaults to nil
 * `node['hollandbackup']['main']['backup_directory']` - see Holland Backup main config-docs, defaults to nil
 * `node['hollandbackup']['main']['backupsets']` - see Holland Backup main config-docs, defaults to nil
 * `node['hollandbackup']['main']['umask']` - see Holland Backup main config-docs, defaults to nil
 * `node['hollandbackup']['main']['path']` - see Holland Backup main config-docs, defaults to nil
 
-### [logging]
+#### [logging]
 * `node['hollandbackup']['main']['filename']` - see Holland Backup main config-docs, defaults to nil
 * `node['hollandbackup']['main']['level']` - see Holland Backup main config-docs, defaults to nil
 
-## backupsets.rb:
+### backupsets.rb:
 
 * `node['hollandbackup']['backupsets']` - A list of backupsets
+
+### cron.rb:
+The `hollandbackup::cron` recipe leverages the [cron lwrp](https://github.com/opscode-cookbooks/cron#resources-and-providers):
+* `node['hollandbackup']['cron']['minute']` - Minute to run hollandbackup, defaults to `0`
+* `node['hollandbackup']['cron']['hour']` - Hour to run hollandbackup, defaults to `3`
+* `node['hollandbackup']['cron']['day']` - Day to run hollandbackup, defaults to `*`
+* `node['hollandbackup']['cron']['month']` - Month to run hollandbackup, defaults to `*`
+* `node['hollandbackup']['cron']['weekday']` - Weekday to run hollandbackup, defaults to `*`
+* `node['hollandbackup']['cron']['user']` - User to run backup as, defaults to `root`
+* `node['hollandbackup']['cron']['command']` - Command to run during backup, defaults to `holland -q backup`
 
 Usage
 =====
@@ -92,6 +109,8 @@ Usage
 5. tweak the attributes via attributes/default.rb
     --- OR ---
     override the attribute on a higher level (http://wiki.opscode.com/display/chef/Attributes#Attributes-AttributesPrecedence)
+
+Optionally add `recipe[hollandbackup::cron]` to setup a cron job to run backups.
 
 References
 ==========

--- a/attributes/cron.rb
+++ b/attributes/cron.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: hollandbackup
+# Attributes:: cron
+#
+
+default['hollandbackup']['cron']['minute'] = '0'
+default['hollandbackup']['cron']['hour'] = '3'
+default['hollandbackup']['cron']['day'] = '*'
+default['hollandbackup']['cron']['month'] = '*'
+default['hollandbackup']['cron']['weekday'] = '*'
+
+default['hollandbackup']['cron']['user'] = 'root'
+default['hollandbackup']['cron']['command'] = 'holland -q backup'

--- a/attributes/cron.rb
+++ b/attributes/cron.rb
@@ -10,4 +10,4 @@ default['hollandbackup']['cron']['month'] = '*'
 default['hollandbackup']['cron']['weekday'] = '*'
 
 default['hollandbackup']['cron']['user'] = 'root'
-default['hollandbackup']['cron']['command'] = 'holland -q backup'
+default['hollandbackup']['cron']['command'] = '/usr/sbin/holland -q backup'

--- a/attributes/repository.rb
+++ b/attributes/repository.rb
@@ -5,4 +5,13 @@
 # Copyright 2012-2014, David Joos
 #
 
-default['hollandbackup']['repository']['distro'] = "xUbuntu_12.04"
+case node['platform']
+  when 'ubuntu'
+    default['hollandbackup']['repository']['distro'] = "xUbuntu_#{node['platform_version']}"
+  when 'centos'
+    default['hollandbackup']['repository']['distro'] = "CentOS_CentOS-#{node['platform_version'].to_i}"
+  when 'debian'
+	default['hollandbackup']['repository']['distro'] = "Debian_#{node['platform_version'].to_i}.0"
+  when 'rhel'
+	default['hollandbackup']['repository']['distro'] = "RedHat_RHEL-#{node['platform_version'].to_i}"
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      "Installs/Configures hollandbackup"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.0"
 
-%w{ debian ubuntu }.each do |os|
+%w{ debian ubuntu rhel centos }.each do |os|
   supports os
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,13 +7,16 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.0"
 
 %w{ debian ubuntu }.each do |os|
-supports os
+  supports os
 end
 
 recommends "mysql"
+
+depends "cron"
 
 recipe "hollandbackup", "Adds the Holland Backup repository."
 recipe "hollandbackup::repository", "Adds the Holland Backup repository."
 recipe "hollandbackup::mysqldump", "Installs & configures the Holland Backup mysqldump provider."
 recipe "hollandbackup::main", "Configures the main Holland Backup settings."
 recipe "hollandbackup::backupsets", "Configures the Holland Backup backupset(s) settings."
+recipe "hollandbackup::cron", "Sets up a cron job to automatically run backups."

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -1,0 +1,14 @@
+#
+# Cookbook Name:: hollandbackup
+# Recipe:: cron
+#
+
+cron_d 'holland-backup' do
+  minute   node['hollandbackup']['cron']['minute']
+  hour     node['hollandbackup']['cron']['hour']
+  day      node['hollandbackup']['cron']['day']
+  month    node['hollandbackup']['cron']['month']
+  weekday  node['hollandbackup']['cron']['weekday']
+  command  node['hollandbackup']['cron']['command']
+  user     node['hollandbackup']['cron']['user']
+end

--- a/recipes/mysqldump.rb
+++ b/recipes/mysqldump.rb
@@ -9,7 +9,10 @@ include_recipe "mysql::client"
 
 package "holland-mysqldump" do
     action :upgrade
-    options "--force-yes"
+    case node['platform_family']
+    when 'debian'
+        options "--force-yes"
+    end
 end
 
 hollandbackup_mysqldump "holland-configure-mysqldump-provider" do

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -32,4 +32,19 @@ case node[:platform]
             command "apt-get update"
             action :nothing
         end
+    when 'centos', 'rhel'
+        distro = node['hollandbackup']['repository']['distro']
+
+        package 'yum-utils'
+
+        execute "hollandbackup-yum-repo-setup" do
+            command "yum-config-manager --add-repo http://download.opensuse.org/repositories/home:/holland-backup/#{distro}/home:holland-backup.repo"
+            notifies :run, "execute[hollandbackup-yum-makecache]", :immediately
+        end
+
+        #update the local package list
+        execute "hollandbackup-yum-makecache" do
+            command "yum makecache"
+            action :nothing
+        end
 end


### PR DESCRIPTION
PR Includes:
- New recipe to run backups with a scheduled cron job (`hollandbackup::cron`)
- A couple small changes to `README.md` formatting
